### PR TITLE
Recipe compare

### DIFF
--- a/birgitta/project/__init__.py
+++ b/birgitta/project/__init__.py
@@ -1,0 +1,7 @@
+"""Project class and functions.
+"""
+
+from .find import find
+from .project import Project
+
+__all__ = ['Project', 'find']

--- a/birgitta/project/find.py
+++ b/birgitta/project/find.py
@@ -1,0 +1,52 @@
+"""find() finds the path of a project within projects path.
+"""
+import glob
+import re
+
+__all__ = ['find']
+
+
+def find(*, path, name):
+    """Look for Project("proj_foo") in __init__.py files
+    under path.
+
+    Since this function should be called to compare code
+    in one git repo with another repo, we do the search in text,
+    not by loading the project modules as python modules.
+    The dependencies for the project modules might not be
+    present. In any case, we are only interested in checking
+    if the content is equal.
+
+    Kwargs:
+        path (str): base path for alll projects e.g.
+        '/path/to/newsltd_etl/projects'.
+        name (str): Project name, as defined in Project('projfoo_name')
+    Returns:
+       Path of project directory.
+    """
+    # Looks through __init__.py files for project constructors.
+    i_suffix = '/__init__.py'
+    inits = glob.glob(f"{path}/*{i_suffix}")
+    for i in inits:
+        name_in_init = proj_name_from_init(i)
+        if name == name_in_init:
+            suf_len = len(i_suffix)
+            proj_path = i[0:-suf_len]
+            return proj_path
+    raise ValueError(f"Project {name} not found in {path}")
+
+
+def proj_name_from_init(i):
+    """Get the project name from __init__.py path i
+
+    Args:
+        i (str): path of a __init__.py file
+    Returns:
+        name from Project('projfoo_name') statement or None.
+    """
+    with open(i) as i_search:
+        for line in i_search:
+            matches = re.match("Project\('([^']+)'\)", line)  # noqa W605
+            if matches:
+                return matches[1]
+    return None

--- a/birgitta/project/project.py
+++ b/birgitta/project/project.py
@@ -1,0 +1,17 @@
+"""The Project class. Defines data set name and schema.
+"""
+
+__all__ = ['Project']
+
+
+class Project:
+    def __init__(self, name):
+        """Constructs a project object.
+
+        The name is important to give flexibility with regards to
+        the underlying project naming.
+
+        Args:
+            name (str): The actual table name.
+        """
+        self.name = name

--- a/birgitta/recipe/diff.py
+++ b/birgitta/recipe/diff.py
@@ -1,0 +1,26 @@
+import difflib
+
+__all__ = ['diff']
+
+
+def diff(*,
+         expected,
+         actual):
+    """
+    Compare two recipe contents.
+
+    Kwargs:
+        expected (str): The expected content to compare
+        actual (str): The actual content to compare
+    Returns:
+       None if equal. Otherwise a diff string.
+    """
+
+    expected = expected.splitlines(1)
+    actual = actual.splitlines(1)
+
+    diff = difflib.unified_diff(expected, actual)
+    ret_str = ''.join(diff)
+    if ret_str == '':
+        return None
+    return ret_str

--- a/birgitta/recipe/find.py
+++ b/birgitta/recipe/find.py
@@ -1,0 +1,47 @@
+from birgitta.project import find
+
+
+__all__ = ['recipe_content', 'recipe_path']
+
+
+def recipe_content(*,
+                   projects_base,
+                   project,
+                   recipe):
+    """
+    Returns the content of a recipe in a project, based on the
+    projects base path, and the project and recipe name.
+
+    Kwargs:
+        projects_base (str): base path for all projects, e.g.
+        '/path/to/newsltd_etl/projects'.
+        project (str): Project name, as defined in Project('projfoo_name')
+        recipe (str): Recipe name e.g. "compute_contracts",
+        as part of recipe file name "compute_contracts.py"
+    Returns:
+       True or False
+    """
+    rpath = recipe_path(projects_base=projects_base,
+                        project=project,
+                        recipe=recipe)
+    return open(rpath).read()
+
+
+def recipe_path(*, projects_base, project, recipe):
+    """
+    Returns the path of a recipe in a project, based on the
+    projects base path, and the project and recipe name.
+    Kwargs:
+        projects_base (str): base path for all projects, e.g.
+        '/path/to/newsltd_etl/projects'.
+        project (str): Project name, as defined in Project('projfoo_name')
+        recipe (str): Recipe name e.g. "compute_contracts",
+        as part of recipe file name "compute_contracts.py"
+    Returns:
+       True or False
+    """
+    project_path = find(
+        path=projects_base,
+        name=project)
+    recipe_path = f"{project_path}/recipes/{recipe}.py"
+    return recipe_path

--- a/newsltd_etl/projects/chronicle/__init__.py
+++ b/newsltd_etl/projects/chronicle/__init__.py
@@ -1,0 +1,3 @@
+from birgitta.project import Project
+
+Project('original_chronicle')

--- a/newsltd_etl/projects/tribune/__init__.py
+++ b/newsltd_etl/projects/tribune/__init__.py
@@ -1,3 +1,3 @@
-# from . import tests
+from birgitta.project import Project
 
-# __all__ = ["tests"]
+Project('tribune')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '0.1.34'
+version = '0.1.35'
 here = path.abspath(path.dirname(__file__))
 
 long_description = """Birgitta is a Python ETL test and schema framework,

--- a/tests/recipe/test_diff.py
+++ b/tests/recipe/test_diff.py
@@ -1,0 +1,43 @@
+import inspect
+import os
+
+import pytest
+from birgitta.recipe import diff, find
+from newsltd_etl import projects
+
+
+@pytest.fixture()
+def projects_path():
+    return os.path.dirname(inspect.getfile(projects))
+
+
+def test_diff(projects_path):
+    recipe_content = find.recipe_content(
+        projects_base=projects_path,
+        project='original_chronicle',
+        recipe='compute_contracts')
+
+    assert not diff.diff(expected=recipe_content,
+                         actual=recipe_content)
+
+
+def test_diff_nequal():
+    simple_content = """first line
+second line
+third line
+"""
+    nequal_content = """zero line
+first line
+SECOND line
+third line
+"""
+    diff_ret = diff.diff(expected=simple_content,
+                         actual=nequal_content)
+    expected_ret = "--- \n" + "+++ \n" + """@@ -1,3 +1,4 @@
++zero line
+ first line
+-second line
++SECOND line
+ third line
+"""
+    assert diff_ret == expected_ret


### PR DESCRIPTION
This can be used to compare the state of a recipe in dataiku with the content
of a file in specific directory structure, e.g. from a downloaded github repo.
The purpose is to use it to validate recipes against git repo during deployment.